### PR TITLE
Handle nonexistent stat() values

### DIFF
--- a/FileCheck.xs
+++ b/FileCheck.xs
@@ -367,6 +367,14 @@ PP(pp_overload_stat) { /* stat & lstat */
       /* Unexpected warning: Attempt to free unreferenced scalar: SV 0x119bd80. */
       //SV *previous_stack = sv_2mortal(POPs); /* what do we want to do with this ? */
       SV *previous_stack = POPs;
+
+      /* Here, we cut early when stat() returned no values
+       * In such a case, we do not want to set the statcache,
+       * nor do we want to call the real op (CALL_REAL_OP)
+      */
+      if ( !size )
+        RETURN;
+
       PUSHs( MUTABLE_SV( PL_defgv ) ); /* add *_ to the stack */
 
       /* copy the content of mocked_stat to PL_statcache */


### PR DESCRIPTION
[This isn't necessarily the best solution, it's just a proof of concept]

The XS code essentially does the following:

* Call a mocked `stat()` function
* Set the statcache
* Call the original Perl code `stat()` function to use the statcache

However, there are two cases in which this causes a problem:
* Nonexistent files
* Broken symlinks

For both of these, the `stat()` command returns empty and sets `$!` to ENOENT (Errno 2, No such file or directory).

The secondary problem is that, if you were to use `-X _`, you would now get a new error from Perl core `stat`. Specifically, you would get EBADF (Errno 9, Bad file descriptor).

What the Perl core does, briefly, is to either return information from the stat or call the underlying system `stat` command. If you send a nonexistent file or a broken symlink, the system `stat` will return ENOENT, which Perl will return to use.

If you call `-X _` to anything, it will avoid calling the `stat` command and in the already-nonexistent file/directory, it will now return a EBADF.

Because the current code sets statcache and then calls the original call, Perl sees it as the second case, where the cache is already populated with empty values that cannot be used. Because of it, Perl avoids calling\ `stat` or even returning values from the cache (what values would it even give if the cache is invalid?) and will instead opt for EBADF.

To avoid this, what this code does is allow setting up what is necessary, but then, instead of pushing values onto the stack, it just returns empty. This *seems* to be the same behavior the user expects.

CAVEATS:

1. That means that all -X tests on nonexistent values *and* broken symlinks
   are invalid. In the test case, I simply skip those tests, because they
   just don't make sense. What could be done is either create a mock object
   for a fake object, but that won't show it as nonexistent, will it? The
   other is to set `$!` and test that. See next caveat.

2. At the moment, to deal with this case, users of `Overload::FileCheck`
   should set errno to ENOENT. This seem burdensome and worth discussion,
   but I also think this is correct. If you are mocking `stat`, you are
   responsible for it setting `$!` to an error. With Perl, C's `stat` function
   sets errno, not Perl. (You could argue that there's a contract with all
   users of `Overload::FileCheck` that an empty `stat` is equivalent to setting
   `$!` to ENOENT. (It's worth checking if C's `stat` can set `$!` to other
   values, because if it can, then the contract will end up a bit more
   complicated or `Overload::FileCheck` will set any error to ENOENT.