### PR TITLE
Set stat cache before adding *_ to stack

### DIFF
--- a/FileCheck.xs
+++ b/FileCheck.xs
@@ -368,17 +368,17 @@ PP(pp_overload_stat) { /* stat & lstat */
       //SV *previous_stack = sv_2mortal(POPs); /* what do we want to do with this ? */
       SV *previous_stack = POPs;
 
+      /* copy the content of mocked_stat to PL_statcache */
+      memcpy(&PL_statcache, &mocked_stat, sizeof(PL_statcache));
+
       /* Here, we cut early when stat() returned no values
-       * In such a case, we do not want to set the statcache,
-       * nor do we want to call the real op (CALL_REAL_OP)
+       * In such a case, we set the statcache, but do not call
+       * the real op (CALL_REAL_OP)
       */
       if ( !size )
         RETURN;
 
       PUSHs( MUTABLE_SV( PL_defgv ) ); /* add *_ to the stack */
-
-      /* copy the content of mocked_stat to PL_statcache */
-      memcpy(&PL_statcache, &mocked_stat, sizeof(PL_statcache));
 
       if ( size ) { /* yes it succeeds */
         PL_laststatval = 0;


### PR DESCRIPTION
The order was:

1. PUSHs *_ to the stack
2. Populate `PL_statcache`
3. Return on empty `stat`

The problem here was that when we returned, PL_statcache was not populated, so `-x` (and other checks in Overload::FileCheck) could not retrieve a value from it (as they use `-x _` to get the value) and thus were not up-to-date on unlinked files (for example). This is what caused cpanel/Test-MockFile#86.

So, theoretically, we would do:

1. PUSHs *_ to the stack
2. Return on empty `stat`
3. Populate `PL_statcache`

If we return from the XS function after the PL_statcache, it's also a problem because we put *_ on the stack so it's now returned when there's an empty `stat` call.

Instead, we need to reverse these:

1. Populate PL_statcache (now `-$check _` will work for Overload::FileCheck)
2. Return on empty `stat` before *_ is put on the stack
3. PUSHs *_ to the stack and other actions